### PR TITLE
chore: remove useless crossing for getter

### DIFF
--- a/gno.land/pkg/integration/testdata/object_pointer.txtar
+++ b/gno.land/pkg/integration/testdata/object_pointer.txtar
@@ -9,7 +9,7 @@ gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func WorkingNew -gas-
 stdout 'OK!'
 gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Set -args 42 -gas-fee 1000000ugnot -gas-wanted 14000000 -broadcast -chainid=tendermint_test test1
 stdout 'OK!'
-gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Get -gas-fee 1000000ugnot -gas-wanted 14000000 -broadcast -chainid=tendermint_test test1
+gnokey query vm/qeval --data "gno.land/r/testing/bug_caller.Get()"
 stdout '42 int' # Works as expected
 
 # 2. (Also working)
@@ -17,7 +17,7 @@ gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func BuggedNew -gas-f
 stdout 'OK!'
 gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Set -args 42 -gas-fee 1000000ugnot -gas-wanted 14000000 -broadcast -chainid=tendermint_test test1
 stdout 'OK!'
-gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Get -gas-fee 1000000ugnot -gas-wanted 14000000 -broadcast -chainid=tendermint_test test1
+gnokey query vm/qeval --data "gno.land/r/testing/bug_caller.Get()"
 stdout '42 int' # Works as expected
 
 
@@ -88,7 +88,5 @@ func Set(value int) {
 }
 
 func Get() int {
-	crossing()
-
 	return callerPtr.Get()
 }

--- a/gnovm/cmd/gno/testdata/test/object_pointer.txtar
+++ b/gnovm/cmd/gno/testdata/test/object_pointer.txtar
@@ -78,8 +78,6 @@ func Set(value int) {
 }
 
 func Get() int {
-	crossing()
-
 	return callerPtr.Get()
 }
 
@@ -96,11 +94,11 @@ import (
 func main() {
 	cross(caller.WorkingNew)()
 	cross(caller.Set)(42)
-	println("With WorkingNew:", cross(caller.Get)())
+	println("With WorkingNew:", caller.Get())
 
 	cross(caller.BuggedNew)()
 	cross(caller.Set)(42)
-	println("With BuggedNew:", cross(caller.Get)())
+	println("With BuggedNew:", caller.Get())
 }
 
 // Output:


### PR DESCRIPTION
Just removed the useless getter if you want to merge it into your branch 😉 